### PR TITLE
Enable key input on macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -687,8 +687,8 @@ impl Game {
     pub fn process_input_event(&mut self, event: &Event<()>) {
         self.process_dispatched_event(event);
 
-        if let Event::DeviceEvent { event, .. } = event {
-            if let DeviceEvent::Key(input) = event {
+        if let Event::WindowEvent { event, .. } = event {
+            if let WindowEvent::KeyboardInput { input, .. } = event {
                 if let ElementState::Pressed = input.state {
                     if let Some(key) = input.virtual_keycode {
                         if key == VirtualKeyCode::Escape {


### PR DESCRIPTION
This PR changes to handle key inputs via `WindowEvent`. I made sure that I can use WASD and ESC on my mac after the commts.

Related issue: [winit#1470](https://github.com/rust-windowing/winit/issues/1470). In short: macOS Accessibilit prevents key inputs from going as `DeviceEvent`, unfortunately.

---
* Most changes in `player.rs` came from early return (change of indentation).