### PR TITLE
Disable mouse smoothing by default

### DIFF
--- a/src/control_scheme.rs
+++ b/src/control_scheme.rs
@@ -93,7 +93,7 @@ impl Default for ControlScheme {
             },
             mouse_sens: 0.3,
             mouse_y_inverse: false,
-            smooth_mouse: true,
+            smooth_mouse: false,
             shake_camera: true,
         }
     }


### PR DESCRIPTION
Mouse smoothing in rusty-shooter for some reason makes aiming feel slow to respond so it should be disabled at least until that's fixed.

I also talked to a decent player in another game who focuses on aim a lot and he confirmed my thoughts: competitive players don't want smoothing in games because it makes them play worse. They want their input as raw and immediate as possible.